### PR TITLE
Chef16 updates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,9 +23,10 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues'
   supports os
 end
 
-depends    'chef_handler', '>= 1.2'
-depends    'apt' # Use '< 6.0.0' with Chef < 12.9
-depends    'yum', '>= 3.0' # Use '< 5.0' with Chef < 12.14
+
+depends('chef_handler', '>= 1.2') if Gem::Requirement.new("< 14").satisfied_by?(Gem::Version.new(Chef::VERSION))
+depends 'apt' # Use '< 6.0.0' with Chef < 12.9
+depends 'yum', '>= 3.0' # Use '< 5.0' with Chef < 12.14
 
 recipe 'datadog::default', 'Default'
 recipe 'datadog::dd-agent', 'Installs the Datadog Agent'

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require 'yaml' # Our erb templates need this
+
 # Fail here at converge time if no api_key is set
 ruby_block 'datadog-api-key-unset' do
   block do

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -1,5 +1,7 @@
 # Configure a service via its yaml file
 
+require 'yaml' # Our erb templates need this
+
 default_action :add
 
 property :name, String, name_attribute: true


### PR DESCRIPTION
required chef16 updates plus some chef12 compatibility

backports fix for 

https://github.com/DataDog/chef-datadog/issues/747
https://github.com/DataDog/chef-datadog/pull/749

issue occurs on subsequent cooks of a previously cooked chef16 node. we must have something else further up in our run list before the datadog cookbook runs that requires the yaml module which does not happen on subsequent runs presumably because whatever resource required it has already been set up. this fixes it so repeated cooks do not fail.

### testing

* cooked a node w/ chef 16 w/o this patch, attempted to recook and saw it failed
* updated berksfile/berksfile.lock to use this cookbook (in my own repo), recooked node and watched the run pass.

can also be replicated w/ test kitchen if desired.